### PR TITLE
DDO-4138 read from gar

### DIFF
--- a/buildSrc/src/main/groovy/tanagra-vumc-admin.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tanagra-vumc-admin.java-conventions.gradle
@@ -14,14 +14,14 @@ repositories {
     }
     maven {
         // Terra proxy for maven central
-        url "https://broadinstitute.jfrog.io/broadinstitute/maven-central/"
+        url "https://us-central1-maven.pkg.dev/dsp-artifact-registry/maven-central/"
     }
     mavenCentral()
     maven {
-        url "https://broadinstitute.jfrog.io/broadinstitute/libs-release/"
+        url "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/"
     }
     maven {
-        url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/"
+        url "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/"
     }
     google()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ pluginManagement {
          }
      }
      maven {
-         url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/"
+         url "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/"
      }
      gradlePluginPortal()
  }


### PR DESCRIPTION
JIRA ticket https://broadworkbench.atlassian.net/browse/DDO-4138


**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Will rely on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).